### PR TITLE
Fix for crash on lack of background color

### DIFF
--- a/MKGradientView/MKGradientView.swift
+++ b/MKGradientView/MKGradientView.swift
@@ -236,7 +236,7 @@ open class MKGradientLayer: CALayer {
     // MARK: Content drawing
     
     override open func draw(in ctx: CGContext) {
-        ctx.setFillColor(backgroundColor!)
+        ctx.setFillColor(backgroundColor ?? UIColor.black.cgColor)
         ctx.fill(bounds)
         
         let img = MKGradientGenerator.gradientImage(type: type, size: bounds.size, colors: colors, colors2: colors2, locations: locations, locations2: locations2, startPoint: startPoint, endPoint: endPoint, startPoint2: startPoint2, endPoint2: endPoint2, scale: contentsScale)


### PR DESCRIPTION
If the MKGradientView didn't have a background color, it would crash (unexpected nil). Maybe only a Swift 4 thing but idk. Now the example on the readme actually works!