### PR TITLE
Correct Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,17 +5,18 @@ import PackageDescription
 let package = Package(
     name: "MKGradientView",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v8),
     ],
     products: [
         .library(
             name: "MKGradientView",
-            targets: ["MKGradientView"]),
+            targets: ["MKGradientView"]
+        ),
     ],
     targets: [
         .target(
             name: "MKGradientView",
-            path: "MKGradientView")
-        )
+            path: "MKGradientView"
+        ),
     ]
 )


### PR DESCRIPTION
Remove extra parenthesis and format `Package.swift`.

I noticed this when I was trying to add it as a dependency within Xcode.